### PR TITLE
Update for newer rollup + inlineAccessors

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var $removeSequence = require("./src/remove-sequence");
 var $removeIIFE = require("./src/remove-iife");
 var $typeclass = require("./src/typeclass");
 var $deadCode = require("./src/dead-code");
+var $inlineAccessors = require("./src/inline-accessors");
 
 
 function pursPath(options, path) {
@@ -279,6 +280,8 @@ module.exports = function (options) {
       // TODO use babel-preset-babili ?
       // TODO use "minify-dead-code-elimination" ?
       plugins.push("minify-constant-folding");
+
+      plugins.push([$inlineAccessors, {debug: options.debug}]);
 
       if (options.optimizations.removeDeadCode) {
         // TODO is this the correct `code` to use ?

--- a/index.js
+++ b/index.js
@@ -98,6 +98,12 @@ module.exports = function (options) {
         entry = rollup.entry;
         rollup.entry = entryPath;
       }
+      if (options.runMain &&
+          rollup.input != null &&
+          rollup.input !== entryPath) {
+        entry = rollup.input;
+        rollup.input = entryPath;
+      }
     },
 
     resolveId: function (filePath, importer) {

--- a/src/inline-accessors.js
+++ b/src/inline-accessors.js
@@ -1,0 +1,48 @@
+"use strict";
+
+module.exports = function inlineAccessors(babel){
+  return {
+    pre: function(){
+      this.accessorsInlined = 0;
+    },
+    post: function(){
+      if (this.opts.debug) {
+        console.info("");
+        console.info("* Accessor inlining statistics");
+        console.info(" * Accessors inlined: " + this.accessorsInlined);
+      }
+    },
+    visitor: {
+      CallExpression: {
+        exit: function (path, state){
+          const propertyName = getPropertyFromPropertyAccessor(path.node.callee);
+          if (!propertyName){return; }
+
+          // debugger;
+          path.replaceWith({
+            type: "MemberExpression",
+            computed: false,
+            property: {type: "Identifier", name: propertyName},
+            object: path.node.arguments[0]
+          });
+          this.accessorsInlined++;
+        }
+      }
+    }
+  };
+};
+
+// Returns the name of the property being accessed if the callee of a CallExpression
+// does nothing more than access a property. If it's not such a "PropertyAccessor"
+// function, we return null
+function getPropertyFromPropertyAccessor(callee){
+  const isPropertyAccessor =
+        callee.type === "FunctionExpression" &&
+        callee.body.type === "BlockStatement" &&
+        callee.body.body.length === 1 &&
+        callee.body.body[0].type === "ReturnStatement" &&
+        callee.body.body[0].argument.type === "MemberExpression";
+  return isPropertyAccessor ?
+    callee.body.body[0].argument.property.name :
+    null;
+}

--- a/unittest/inline-accessors.js
+++ b/unittest/inline-accessors.js
@@ -1,0 +1,23 @@
+const assert = require("assert");
+const $babel = require("babel-core");
+const inlineAccessors = require("../src/inline-accessors.js");
+
+const testCases = [{
+  codeIn: "var obj = { b: 2 };var b = function (a){ return a.b; }(obj);",
+  result: "var obj = { b: 2 };var b = obj.b;"
+}];
+
+testCases.forEach(async function(testCase){
+  var result = $babel.transform(testCase.codeIn, {
+    babelrc: false,
+    code: true,
+    ast: true,
+    sourceMaps: false,
+    plugins: [
+      [inlineAccessors, {debug: true}]
+    ]
+  });
+
+  assert(result.code === testCase.result, `${result.code} is not equal to ${testCase.result}`);
+});
+


### PR DESCRIPTION
Hey,

This adds two things:

First, the newer rollup versions (not sure starting from which one) prefer options.input instead of options.entry, so I added support for that. Without this, the main call is not made correctly and everything gets DCE'd :).

Second, this adds an optimization that I've been wanting for a long time. It inlines accessor functions. You can check the unittest for an example. I've always hated that PS makes a ton of these accessor functions and now that I've discovered your plugin I'm very happy I could do something about it :). You can run this unittest with ```node unittest/inline-accessors.js```. It's a very simple kind of unit test, doesn't require any framework or nothing, but if you prefer to have these run another way, let me know.

Simon