### PR TITLE
Added support for options.input for newer versions of rollup

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,12 @@ module.exports = function (options) {
         entry = rollup.entry;
         rollup.entry = entryPath;
       }
+      if (options.runMain &&
+          rollup.input != null &&
+          rollup.input !== entryPath) {
+        entry = rollup.input;
+        rollup.input = entryPath;
+      }
     },
 
     resolveId: function (filePath, importer) {


### PR DESCRIPTION
Hey,

Newer versions of rollup (not sure from which version onward) use options.input instead of options.entry, so I added support for that here aswell.